### PR TITLE
Adds the host's hostname to the tags

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -55,7 +55,7 @@ func (e *exporter) ExportView(viewData *view.Data) {
 		}
 
 		tagsMap := convertTags(row.Tags)
-		tagsMap = addHostnameTag(tagsMap)
+		addHostnameTag(tagsMap)
 
 		pt, err := client.NewPoint(viewData.View.Name, tagsMap, fields, viewData.End)
 		if err != nil {
@@ -70,12 +70,13 @@ func (e *exporter) ExportView(viewData *view.Data) {
 	}
 }
 
-func addHostnameTag(tagsMap map[string]string) map[string]string {
+func addHostnameTag(tagsMap map[string]string) {
 	hostname, err := os.Hostname()
 	if err == nil {
 		tagsMap["hostname"] = hostname
+	} else {
+		tagsMap["hostname"] = "unknown"
 	}
-	return tagsMap
 }
 
 func convertTags(tags []tag.Tag) map[string]string {

--- a/exporter.go
+++ b/exporter.go
@@ -22,7 +22,6 @@ type exporter struct {
 	customTags   map[string]string
 }
 
-// ExportView
 func (e *exporter) ExportView(viewData *view.Data) {
 	bp, err := client.NewBatchPoints(client.BatchPointsConfig{
 		Database:  e.database,
@@ -70,16 +69,16 @@ func (e *exporter) ExportView(viewData *view.Data) {
 	}
 }
 
-// appendAndReplace appends all the data from the second map (toAppend) to the
-// source map. If both have the same key, the one from the second map (toAppend)
+// appendAndReplace appends all the data from the 'elementsMap' to the
+// 'appendable' map. If both have the same key, the one from 'elementsMap'
 // is taken.
-func appendAndReplace(source, toAppend map[string]string) {
-	if source == nil || toAppend == nil {
+func appendAndReplace(appendable, elementsMap map[string]string) {
+	if appendable == nil {
 		return
 	}
 
-	for k, v := range toAppend {
-		source[k] = v
+	for k, v := range elementsMap {
+		appendable[k] = v
 	}
 }
 

--- a/exporter.go
+++ b/exporter.go
@@ -31,24 +31,19 @@ func (e *exporter) ExportView(viewData *view.Data) {
 
 	for _, row := range viewData.Rows {
 		fields := make(map[string]interface{})
-		var suffix string
 
 		switch d := row.Data.(type) {
 		case *view.CountData:
 			fields["value"] = float64(d.Value)
-			suffix = ".count"
 		case *view.DistributionData:
 			fields["min"] = d.Min
 			fields["max"] = d.Max
 			fields["mean"] = d.Mean
 			fields["count"] = d.Count
-			suffix = ".histogram"
 		case *view.LastValueData:
 			fields["value"] = float64(d.Value)
-			suffix = ".gauge"
 		case *view.SumData:
 			fields["value"] = float64(d.Value)
-			suffix = ".gauge"
 		default:
 			e.errorHandler(fmt.Errorf("unknown AggregationData type: %T", row.Data))
 			return

--- a/exporter.go
+++ b/exporter.go
@@ -69,16 +69,16 @@ func (e *exporter) ExportView(viewData *view.Data) {
 	}
 }
 
-// appendAndReplace appends all the data from the 'elementsMap' to the
-// 'appendable' map. If both have the same key, the one from 'elementsMap'
+// appendAndReplace appends all the data from the 'src' to the
+// 'dst' map. If both have the same key, the one from 'src'
 // is taken.
-func appendAndReplace(appendable, elementsMap map[string]string) {
-	if appendable == nil {
+func appendAndReplace(dst, src map[string]string) {
+	if dst == nil {
 		return
 	}
 
-	for k, v := range elementsMap {
-		appendable[k] = v
+	for k, v := range src {
+		dst[k] = v
 	}
 }
 


### PR DESCRIPTION
If the hostname cannot be parsed due to an error, "unknown" is added to the tags. This helps group values from multiple pods.